### PR TITLE
bump and minimize imports

### DIFF
--- a/LLMstep/LLMstep.lean
+++ b/LLMstep/LLMstep.lean
@@ -3,11 +3,14 @@
 Examples:
  llmstep ""
  llmstep "have"
- llmstep "apply Continuous" 
+ llmstep "apply Continuous"
 
 Author: Sean Welleck
 -/
-import Mathlib.Tactic
+import Lean.Widget.UserWidget
+import Std.Lean.Position
+import Std.Lean.Format
+import Std.Data.String.Basic
 
 open Lean
 
@@ -21,8 +24,8 @@ def runSuggest (args : Array String) : IO String := do
   let s ← IO.Process.run { cmd := "python3", args := #[path.toString] ++ args }
   return s
 
-/- Display clickable suggestions in the VSCode Lean Infoview. 
-    When a suggestion is clicked, this widget replaces the `llmstep` call 
+/- Display clickable suggestions in the VSCode Lean Infoview.
+    When a suggestion is clicked, this widget replaces the `llmstep` call
     with the suggestion, and saves the call in an adjacent comment.
     Code based on `Std.Tactic.TryThis.tryThisWidget`. -/
 @[widget] def llmstepTryThisWidget : Widget.UserWidgetDefinition where
@@ -35,23 +38,23 @@ export default function(props) {
   const editorConnection = React.useContext(EditorContext)
   function onClick(suggestion) {
     editorConnection.api.applyEdit({
-      changes: { [props.pos.uri]: [{ range: 
-        props.range, 
+      changes: { [props.pos.uri]: [{ range:
+        props.range,
         newText: suggestion + ' -- ' + props.tactic
         }] }
     })
   }
-  return e('div', 
-  {className: 'ml1'}, 
+  return e('div',
+  {className: 'ml1'},
   e('ul', {className: 'font-code pre-wrap'}, [
     'Try this: ',
-    ...(props.suggestions.map((suggestion, i) => 
-        e('li', {onClick: () => onClick(suggestion), 
-          className: 
-            props.checks[i] === 'ProofDone' ? 'link pointer dim green' : 
-            props.checks[i] === 'Valid' ? 'link pointer dim blue' : 
-            'link pointer dim', 
-          title: 'Apply suggestion'}, 
+    ...(props.suggestions.map((suggestion, i) =>
+        e('li', {onClick: () => onClick(suggestion),
+          className:
+            props.checks[i] === 'ProofDone' ? 'link pointer dim green' :
+            props.checks[i] === 'Valid' ? 'link pointer dim blue' :
+            'link pointer dim',
+          title: 'Apply suggestion'},
           props.checks[i] === 'ProofDone' ? '🎉 ' + suggestion : suggestion
       )
     )),
@@ -72,24 +75,24 @@ def checkSuggestion (s: String) : Lean.Elab.Tactic.TacticM CheckResult := do
   withoutModifyingState do
   try
     match Parser.runParserCategory (← getEnv) `tactic s with
-      | Except.ok stx => 
+      | Except.ok stx =>
         try
           _ ← Lean.Elab.Tactic.evalTactic stx
           let goals ← Lean.Elab.Tactic.getUnsolvedGoals
           if (← getThe Core.State).messages.hasErrors then
             pure CheckResult.Invalid
-          else if goals.isEmpty then 
+          else if goals.isEmpty then
             pure CheckResult.ProofDone
           else
             pure CheckResult.Valid
-        catch _ => 
+        catch _ =>
           pure CheckResult.Invalid
-      | Except.error _ => 
+      | Except.error _ =>
         pure CheckResult.Invalid
     catch _ => pure CheckResult.Invalid
 
 
-/- Adds multiple suggestions to the Lean InfoView. 
+/- Adds multiple suggestions to the Lean InfoView.
    Code based on `Std.Tactic.addSuggestion`. -/
 def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
     (origSpan? : Option Syntax := none)
@@ -103,7 +106,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       let checks ← suggestions.mapM checkSuggestion
       let texts := suggestions.map fun text => (
         (Std.Format.prettyExtra (text.stripSuffix "\n")
-         (indent := (body - start).1) 
+         (indent := (body - start).1)
          (column := (tacticRange.start - start).1)
       ))
 
@@ -127,15 +130,15 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       let stxRange :=
       { start := map.lineStart (map.toPosition start).line
         stop := map.lineStart ((map.toPosition stop).line + 1) }
-      let full_range : String.Range := 
+      let full_range : String.Range :=
       { start := tacticRange.start, stop := argRange.stop }
       let full_range := map.utf8RangeToLspRange full_range
       let tactic := Std.Format.prettyExtra f!"{tacRef.prettyPrint}{pfxRef.prettyPrint}"
       let json := Json.mkObj [
         ("tactic", tactic),
-        ("suggestions", toJson texts), 
+        ("suggestions", toJson texts),
         ("checks", toJson checks),
-        ("range", toJson full_range), 
+        ("range", toJson full_range),
         ("info", extraMsg)
       ]
       Widget.saveWidgetInfo ``llmstepTryThisWidget json (.ofRange stxRange)
@@ -155,4 +158,4 @@ elab_rules : tactic
       let ppgoalstr := toString ppgoal
       let suggest ← runSuggest #[ppgoalstr, pfx.getString]
       addSuggestions tac pfx $ suggest.splitOn "[SUGGESTION]"
-  
+

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,30 +4,36 @@
  [{"git":
    {"url": "https://github.com/EdAyers/ProofWidgets4",
     "subDir?": null,
-    "rev": "c43db94a8f495dad37829e9d7ad65483d68c86b8",
+    "rev": "a0c2cd0ac3245a0dade4f925bcfa97e06dd84229",
     "name": "proofwidgets",
-    "inputRev?": "v0.0.11"}},
+    "inputRev?": "v0.0.13"}},
+  {"git":
+   {"url": "https://github.com/mhuisi/lean4-cli.git",
+    "subDir?": null,
+    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "name": "Cli",
+    "inputRev?": "nightly"}},
   {"git":
    {"url": "https://github.com/leanprover-community/mathlib4.git",
     "subDir?": null,
-    "rev": "a3b66ecb2f91d93379698626e7ec98a28b893b4d",
+    "rev": "adb6afd84bba23ae3d29609ea10775a3c0872046",
     "name": "mathlib",
     "inputRev?": null}},
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "c71f94e34c1cda52eef5c93dc9da409ab2727420",
+    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "ca73109cc40837bc61df8024c9016da4b4f99d4c",
+    "rev": "d13a9666e6f430b940ef8d092f1219e964b52a09",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "e68aa8f5fe47aad78987df45f99094afbcb5e936",
+    "rev": "8b864260672b21d964d79ecb2376e01d0eab9f5b",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-06-20
+leanprover/lean4:nightly-2023-08-15


### PR DESCRIPTION
By bumping to current Mathlib master, we see that for the tactic itself no Mathlib imports are needed.