### PR TITLE
Local inference with llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,41 @@ python python/server_vllm.py
 ```
 Fast suggestions are optional; you can use `python/server.py` to run `llmstep` without vLLM.
 
+## Local inference with llama.cpp
+The standard server and vLLM server are intended to run on GPUs. However, `llmstep` also includes `python/server_ggml.py`, an experimental [llama.cpp](https://github.com/ggerganov/llama.cpp) based server intended to run efficiently on CPUs. Currently, the llama.cpp server supports only one tactic suggestion per `llmstep` call. 
+
+Configuring `python/server_ggml.py` requires a few extra steps. Note that the official [llmstep model](https://huggingface.co/wellecks/llmstep-mathlib4-pythia2.8b) is not compatible with the llama.cpp server. Instead, download the experimental [zhangirazerbayev/open-llama-3b_next-tactic_dev0.2](https://huggingface.co/zhangirazerbayev/open-llama-3b_next-tactic_dev0.2) as follows:
+```bash
+# Make sure you have git-lfs installed (https://git-lfs.com)
+git lfs install
+git clone https://huggingface.co/zhangirazerbayev/open-llama-3b_next-tactic_dev0.2
+```
+The following steps will install llama.cpp and convert the above model to an executable binary. 
+```bash
+git clone https://github.com/ggerganov/llama.cpp
+cd llama.cpp
+make
+
+# install llama.cpp python dependencies
+python3 -m pip install -r requirements.txt
+
+# convert the model you downloaded to ggml FP16 format
+python3 convert.py $PATH_TO_MODEL
+```
+This will produce a file named `ggml-model-f32.bin` in the `$PATH_TO_MODEL` directory. 
+
+If the above steps do not work for you, please, consult the more detailed instructions in the [llama.cpp](https://github.com/ggerganov/llama.cpp) repository.
+
+In the following step, you will quantize your model to a reduced precision format. The available formats are `F16, Q8_0, Q5_1, Q5_0, Q4_1, Q4_0`, with lower precision formats trading off accuracy for latency and memory. I would recommend starting with `Q4_0`, and increasing precision if your hardware handles lower precisions comfortably. 
+```bash
+./quantize $PATH_TO_MODEL/ggml-model-f32.bin $PATH_TO_QUANTIZED
+```
+Then, you may start `server_ggml.py` as follows
+```bash
+python server_ggml.py --model_path $PATH_TO_QUANTIZED
+```
+Once the server is running, use `llmstep` as you normally would. 
+
 ## Language model
 By default, `llmstep` uses a Pythia 2.8b language model fine-tuned on [LeanDojo Benchmark 4](https://zenodo.org/record/8040110):
 - [`llmstep` model on Huggingface](https://huggingface.co/wellecks/llmstep-mathlib4-pythia2.8b)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In the following step, you will quantize your model to a reduced precision forma
 ```
 Then, you may start `server_ggml.py` as follows
 ```bash
-python server_ggml.py --model_path $PATH_TO_QUANTIZED
+python3 python/server_ggml.py --model_path $PATH_TO_QUANTIZED
 ```
 Once the server is running, use `llmstep` as you normally would. 
 

--- a/python/server_ggml.py
+++ b/python/server_ggml.py
@@ -1,0 +1,51 @@
+from flask import Flask, request, jsonify
+
+from llama_cpp import Llama 
+
+import argparse
+import os
+import time
+
+EOS = "[EOS]"
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+        '--model_path', 
+        type=str, 
+        default='/home/zhangir/projects/llama.cpp/models/ggml-open-llama-3b-q4_0.bin'
+        )
+args = parser.parse_args()
+
+def load_ggml(model_path):
+    print(f"loading {model_path}...")
+    llm = Llama(model_path=model_path)
+    print("Done.")
+    return llm
+
+def generate(prompt) -> str:
+    output = model(prompt, max_tokens=128, stop=EOS)
+    return output["choices"][0]['text']
+
+model = load_ggml(args.model_path)
+app = Flask(__name__)
+
+@app.route('/', methods=['POST'])
+def process_request():
+    start = time.time()
+    data = request.get_json()
+
+    tactic_state = data.get('tactic_state')
+    prefix = data.get('prefix')
+
+    prompt = """[GOAL]%s[PROOFSTEP]%s""" % (tactic_state, prefix)
+    texts = [prefix + generate(prompt)]
+
+    response = {"suggestions": texts}
+    end = time.time()
+    print("%d suggestions (%.3fs)" % (len(texts), (end-start)))
+    return jsonify(response)
+
+
+if __name__ == '__main__':
+    port = os.environ.get('LLMSTEP_PORT', 5000)
+    app.run(use_reloader=False, host='0.0.0.0', port=port)

--- a/python/server_ggml.py
+++ b/python/server_ggml.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
         '--model_path', 
         type=str, 
-        default='/home/zhangir/projects/llama.cpp/models/ggml-open-llama-3b-q4_0.bin'
+        help="Path to a llama.cpp model binary"
         )
 args = parser.parse_args()
 

--- a/python/server_ggml.py
+++ b/python/server_ggml.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import time
 
-EOS = "[EOS]"
+EOS = "<|endoftext|>"
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 transformers
 torch
+llama-cpp-python


### PR DESCRIPTION
This PR adds support for an inference server powered by [llama.cpp](https://github.com/ggerganov/llama.cpp) that runs efficiently on CPU. I am able to get a tactic suggestion in a few seconds on my 5 year old thinkpad. 

See the additions to the README for installation and configuration instructions. 

Unfortunately, the GPTNeoX architecture of the official llmstep model isn't supported by the llama.cpp library. I threw together quick finetune of [open_llama_3b_v2](https://huggingface.co/openlm-research/open_llama_3b_v2), which you can find here: [open-llama-3b_next-tactic_dev0.2](https://huggingface.co/zhangirazerbayev/open-llama-3b_next-tactic_dev0.2). Note this model is extremely undertrained (less than one A100-hour), so should be viewed only as a proof of concept that inference latency on CPU can be acceptable. Training an open-llama that matches the llmstep model will be quite trivial. 

A substantial refactor of `python/train/tune.py` was required train the open llama. But that code is still incredibly messy and I will PR it once I clean it up a bit. 

The reasons this PR is a draft are:
1. The inference server crashes if you move around your cursor too much after typing `llmstep ""`. For now it is best to not move your cursor after typing the empty string, and actually putting text in the string almost always causes a crash. 
2. Currently, this implementation only supports generating one tactic step per `llmstep` call. The CPU won't handle parallel decoding well like the GPU can, but we might want to add a "get another suggestion" button or something of the sort. 
3. We probably want to train the better model compatible with llama.cpp before merging into main. 

