### PR TITLE
fix data.py argument

### DIFF
--- a/python/train/data.py
+++ b/python/train/data.py
@@ -94,7 +94,7 @@ def proofstep(data_dir):
 
 
 def main(args):
-    proofstep(args.datadir)
+    proofstep(args.data_dir)
 
 
 def setup(args):


### PR DESCRIPTION
When running the original code, I am getting:

```

 python3 data.py --data-dir ~/coding/ai/llmstep/data
Traceback (most recent call last):
  File "/Users/josojo/coding/ai/llmstep/python/train/data.py", line 117, in <module>
    main(args)
  File "/Users/josojo/coding/ai/llmstep/python/train/data.py", line 97, in main
    proofstep(args.datadir)
              ^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'datadir'. Did you mean: 'data_dir'?
```

Hence the fix.