### PR TITLE
Display helpful message when suggest returns no valid suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .DS_Store
 *.pyc
+*.olean

--- a/LLMstep/LLMstep.lean
+++ b/LLMstep/LLMstep.lean
@@ -52,22 +52,26 @@ export default function(props) {
         }] }
     })
   }
+  const suggestionElement = props.suggestions.length > 0
+    ? [
+      'Try this: ',
+      ...(props.suggestions.map((suggestion, i) =>
+          e('li', {onClick: () => onClick(suggestion),
+            className:
+              suggestion[1] === 'ProofDone' ? 'link pointer dim green' :
+              suggestion[1] === 'Valid' ? 'link pointer dim blue' :
+              'link pointer dim',
+            title: 'Apply suggestion'},
+            suggestion[1] === 'ProofDone' ? '🎉 ' + suggestion[0] : suggestion[0]
+        )
+      )),
+      props.info
+    ]
+    : 'No valid suggestions.';
   return e('div',
   {className: 'ml1'},
-  e('ul', {className: 'font-code pre-wrap'}, [
-    'Try this: ',
-    ...(props.suggestions.map((suggestion, i) =>
-        e('li', {onClick: () => onClick(suggestion),
-          className:
-            suggestion[1] === 'ProofDone' ? 'link pointer dim green' :
-            suggestion[1] === 'Valid' ? 'link pointer dim blue' :
-            'link pointer dim',
-          title: 'Apply suggestion'},
-          suggestion[1] === 'ProofDone' ? '🎉 ' + suggestion[0] : suggestion[0]
-      )
-    )),
-    props.info
-  ]))
+  e('ul', {className: 'font-code pre-wrap'},
+  suggestionElement))
 }"
 
 inductive CheckResult : Type


### PR DESCRIPTION
The current Infoview displays "Try this:" without any subsequent content when there are no valid suggestions. With this PR, the Infoview displays the message "No valid suggestions." instead.

Before:
![image](https://github.com/wellecks/llmstep/assets/342514/1f40bdbf-10c3-48a1-ae90-fdcff4f64855)

After:
<img width="1679" alt="image" src="https://github.com/wellecks/llmstep/assets/342514/1652f96a-c0d4-481d-93bc-0d233594c7c0">
